### PR TITLE
Labur.eus: Bertsio berrira egokitzeko aldaketak

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -28,7 +28,7 @@ function labur_plugin_options() { // Page design. This function is called in adm
         <h2>Labur Wordpress Plugin</h2>
         <form action="<?php echo esc_url( admin_url('options.php') ); ?>" method="post">
             <?php settings_fields('labur-group'); ?>
-            <?php @do_settings_fields('labur-group'); ?>
+            <?php @do_settings_sections('labur-group'); ?>
             <table class="form-table">
                 <tr valign="top">
                     <th scope="row"><label for="labur_dashboard_title"><?php echo esc_html(__('API key', 'wp-labur')); ?></label></th>

--- a/labur.js
+++ b/labur.js
@@ -1,22 +1,25 @@
-jQuery(document).ready(function($) {
-    jQuery("#button_labur_get_url").click(function(){
-
-    var url = MyAjax.ajax_path;
-    jQuery.ajax({
+document.addEventListener("DOMContentLoaded", function(event) {
+    document.getElementById('button_labur_get_url').addEventListener('click', () => {
+        jQuery.ajax({
             type: 'POST',
-            url: url,
-            dataType: 'text',
-
+            url: MyAjax.ajax_path,
+            dataType: 'json',
             data: {
-                postID: MyAjax.post_id, // From PHP
-                action: MyAjax.action // From PHP-tik
+                postID: MyAjax.post_id,
+                action: MyAjax.action
             },
-            success: function(data, textStatus, XMLHttpRequest){
-                $('#labur_shortened_url').val(data);
-            },
-            error: function(MLHttpRequest, textStatus, errorThrown){
-                alert(errorThrown);
+            async: true
+            
+        }).done((data) => {
+            if (data.success) {
+                jQuery('#labur_shortened_url').val(data.data)
+            } else {
+                alert(data.data)
             }
-        });
+
+        }).error(() => {
+            alert(data)
+
+        })
     });
 });

--- a/labur.php
+++ b/labur.php
@@ -94,7 +94,7 @@ function labur_get_url_process() {
         $labur_url = 'https://' . $result['data']->domeinua . '/' . $result['data']->laburdura;
         wp_send_json_success($labur_url);
       } else {
-        wp_send_json_error($result['data']->url);
+        wp_send_json_error($result['data']->message);
       }
     }
 

--- a/labur.php
+++ b/labur.php
@@ -91,10 +91,16 @@ function labur_get_url_process() {
 
       $result = laburtu($post_url);
       if ($result['status'] == 201) {
-        $labur_url = 'https://' . $result['data']->domeinua . '/' . $result['data']->laburdura;
-        wp_send_json_success($labur_url);
+        $shortenedurl = 'https://' . $result['data']->domeinua . '/' . $result['data']->laburdura;
+
+        // Gorde labur esteka
+        update_post_meta($post_id, 'labur_shortened_url', esc_url_raw($shortenedurl));
+         
+        wp_send_json_success($shortenedurl);
+
       } else {
         wp_send_json_error($result['data']->message);
+
       }
     }
 


### PR DESCRIPTION
Otsailaren 24an labur.eus bertsio berria aterako da eta API deian aldaketak ekarriko ditu. Plugina bertsio berrira egokitu da, aldaketak aplikatu ezean Otsailaren 24tik aurrera ez da ibiliko.

**Egindako aldaketak**
* labur.eus API bertsio berrira egokitu.
* WP 6.7.2 bertsioa arte bateragarri jarri da.